### PR TITLE
Add classes for labels/lists to work, decode labels/title correctly

### DIFF
--- a/src/scraper.js
+++ b/src/scraper.js
@@ -17,9 +17,9 @@ const extractFromDOM = (dir, filename) => {
 
   const keepDate = keepNote.find('.heading').text().trim();
 
-  const date = moment(keepDate, 'MMM D, YYYY, h:mm:ss A', true).toISOString();
-  const title = keepNote.find('.title').text().trim();
   const contentRoot = keepNote.find('.content');
+  const date = moment(keepDate, 'MMM D, YYYY, h:mm:ss A', true).toISOString();
+  let title = keepNote.find('.title').text().trim();
   let content = '';
   let labels = [];
 
@@ -27,10 +27,10 @@ const extractFromDOM = (dir, filename) => {
     return null;
   }
 
-  if (contentRoot.find('div.listitem').length) {
+  if (contentRoot.find('li.listitem').length) {
     // Keep Note type: list
     content = contentRoot
-      .find('div.text')
+      .find('span.text')
       .map((v, i) => $(i).html().trim())
       .get()
       .join('\n');
@@ -42,16 +42,17 @@ const extractFromDOM = (dir, filename) => {
       .join('\n');
   }
 
-  if (keepNote.find('div.labels').length) {
+  if (keepNote.find('div.chips').length) {
     labels = keepNote
-      .find('span.label')
+      .find('span.label-name')
       .map((v, i) => $(i).html().trim())
       .get();
   }
 
   // decode HTML entities with he as cheerio has issues with that
+  title = he.decode(title);
   content = he.decode(content);
-  labels.map(label => he.decode(label));
+  labels = labels.map(label => he.decode(label));
 
   const keepObject = { date, title, content };
   if (labels.length) {

--- a/test/scraper.spec.js
+++ b/test/scraper.spec.js
@@ -46,8 +46,12 @@ test.before('prep', () => {
           <div class="heading">${testDates.valid2016}</div>
           <div class="title">qux</div>
           <div class="content">qux</div>
-          <div class="labels">
-            <span class="label">quxLabel</span>
+          <div class="chips">
+            <span class="chip label">
+              <span class="label-name">
+                quxLabel
+              </span>
+            </span>
           </div>
         </div>`,
       'multiLabeledTextNote.html': `
@@ -55,9 +59,13 @@ test.before('prep', () => {
           <div class="heading">${testDates.valid2016}</div>
           <div class="title">quux</div>
           <div class="content">quux</div>
-          <div class="labels">
-            <span class="label">quuxFirstLabel</span>
-            <span class="label">quuxSecondLabel</span>
+          <div class="chips">
+            <span class="chip label">
+              <span class="label-name">quuxFirstLabel</span>
+            </span>
+            <span class="chip label">
+              <span class="label-name">quuxSecondLabel</span>
+            </span>
           </div>
         </div>`,
     },
@@ -67,13 +75,17 @@ test.before('prep', () => {
           <div class="heading">${testDates.valid2016}</div>
           <div class="title">corge</div>
           <div class="content">
-            <div class="listitem">
-              <div class="bullet">&#9744;</div>
-              <div class="text">corgeSingleItem</div>
-            </div>
+            <ul class="list">
+              <li class="listitem">
+                <span class="bullet">☐</span>
+                <span class="text">corgeSingleItem</span>
+              </li>
+            </ul>
           </div>
-          <div class="labels">
-            <span class="label">corgeLabel</span>
+          <div class="chips">
+            <span class="chip label">
+              <span class="label-name">corgeLabel</span>
+            </span>
           </div>
         </div>`,
       'multiListItemNote.html': `
@@ -81,14 +93,16 @@ test.before('prep', () => {
           <div class="heading">${testDates.valid1970}</div>
           <div class="title">grault</div>
           <div class="content">
-            <div class="listitem">
-              <div class="bullet">&#9744;</div>
-              <div class="text">graultFirstItem</div>
-            </div>
-            <div class="listitem">
-              <div class="bullet">&#9744;</div>
-              <div class="text">graultSecondItem</div>
-            </div>
+            <ul class="list">
+              <li class="listitem">
+                <span class="bullet">☐</span>
+                <span class="text">graultFirstItem</span>
+              </li>
+              <li class="listitem">
+                <span class="bullet">☐</span>
+                <span class="text">graultSecondItem</span>
+              </li>
+            </ul>
           </div>
         </div>`,
     },


### PR DESCRIPTION
Changed the classes in order to work with the new format. Fixed tests too.

For labels, "labels" is changed to "chips", and "label" to "label-name". For lists, "listitem" is changed from a div to a li, and the "text" div is now a span. 

I also made some changes to the decoded properties. I fixed a bug with "labels", which was using "map", but was not assigning the decoded property to any variable. The reason is that map does not alter the original array. Finally, I also decode "title", because I had issues with Greek characters.

Thanks for this package, it was really helpful.