### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm test


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` — runs `npm test` on every push and pull request to `master`
- Uses Node 24 (matches `engines` requirement in `package.json`)
- Uses `npm ci` for a clean, lockfile-based install

## After merging

To make CI blocking (resolves the "master isn't protected" warning on the repo homepage):

1. Go to **Settings → Branches → Add branch protection rule**
2. Set branch name pattern to `master`
3. Enable **Require status checks to pass before merging** and select `CI / test`
4. Optionally enable **Require a pull request before merging**

## Test plan

- [ ] CI run triggered on this PR passes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)