### PR TITLE
Add automated npm publish on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+
+      - run: npm test
+
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` — triggers when a GitHub Release is published
- Runs `npm test` first; only publishes if tests pass
- Authenticates with npm via `NPM_TOKEN` repository secret (already added)

## How to publish a new version going forward

1. Update the version in `package.json`
2. Commit and merge to `master`
3. On GitHub: **Releases → Draft a new release → Create a new tag** (e.g. `v2.0.0`) → **Publish release**
4. This workflow runs automatically — tests then `npm publish`

## Test plan

- [ ] CI passes green on this PR
- [ ] After merging: create a release and verify the publish workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)