### PR TITLE
Switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -21,6 +23,4 @@ jobs:
 
       - run: npm test
 
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --provenance


### PR DESCRIPTION
## Summary

- Replaces `NPM_TOKEN` secret with OIDC-based Trusted Publishing
- Adds `permissions: id-token: write` so GitHub can issue an OIDC token
- Adds `--provenance` flag for cryptographic build attestation
- The `NPM_TOKEN` secret can be deleted from repo settings after this merges

## Why

The previous token-based approach required bypassing npm 2FA, which npm flags as a security risk. Trusted Publishing uses GitHub's built-in OIDC identity — no long-lived secret to store or rotate.

## Test plan

- [ ] CI passes green on this PR
- [ ] After merging: create a release and verify the publish workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)